### PR TITLE
Build with system libjq (i.e. Debian libjq-dev or EPEL jq-devel)

### DIFF
--- a/jq/jq.go
+++ b/jq/jq.go
@@ -16,8 +16,7 @@ $ make install-libLTLIBRARIES install-includeHEADERS
 */
 
 /*
-#cgo CFLAGS: -I ${SRCDIR}/../jq-1.5/BUILD/include
-#cgo LDFLAGS: ${SRCDIR}/../jq-1.5/BUILD/lib/libjq.a
+#cgo LDFLAGS: -ljq
 #cgo linux LDFLAGS: -lm
 
 

--- a/jq/jv.go
+++ b/jq/jv.go
@@ -1,8 +1,7 @@
 package jq
 
 /*
-#cgo CFLAGS: -I ${SRCDIR}/../jq-1.5/BUILD/include
-#cgo LDFLAGS: ${SRCDIR}/../jq-1.5/BUILD/lib/libjq.a
+#cgo LDFLAGS: -ljq
 
 #include <stdlib.h>
 


### PR DESCRIPTION
As it is, it's not actually possible to "go get" this thing without a pre-constructed environment. This makes it work on reasonable systems. jq doesn't have a pkg-config or anything, so just assume that the includes and libs are in a global path (as indeed they usually are).