### PR TITLE
Add support for more value types to the Jv type

### DIFF
--- a/jq/jv_test.go
+++ b/jq/jv_test.go
@@ -66,6 +66,88 @@ func TestJvFromJSONString(t *testing.T) {
 	is.Nil(jv)
 }
 
+func TestJvFromFloat(t *testing.T) {
+	is := is.New(t)
+
+	jv := jq.JvFromFloat(1.23)
+	is.OK(jv)
+	is.Equal(jv.Kind(), jq.JV_KIND_NUMBER)
+	gv := jv.ToGoVal()
+	n, ok := gv.(float64)
+	is.True(ok)
+	is.Equal(n, float64(1.23))
+}
+
+func TestJvFromInterface(t *testing.T) {
+	is := is.New(t)
+
+	// Null
+	jv, err := jq.JvFromInterface(nil)
+	is.NoErr(err)
+	is.OK(jv)
+	is.Equal(jv.Kind(), jq.JV_KIND_NULL)
+
+	// Boolean
+	jv, err = jq.JvFromInterface(true)
+	is.NoErr(err)
+	is.OK(jv)
+	is.Equal(jv.Kind(), jq.JV_KIND_TRUE)
+
+	jv, err = jq.JvFromInterface(false)
+	is.NoErr(err)
+	is.OK(jv)
+	is.Equal(jv.Kind(), jq.JV_KIND_FALSE)
+
+	// Float
+	jv, err = jq.JvFromInterface(1.23)
+	is.NoErr(err)
+	is.OK(jv)
+	is.Equal(jv.Kind(), jq.JV_KIND_NUMBER)
+	gv := jv.ToGoVal()
+	n, ok := gv.(float64)
+	is.True(ok)
+	is.Equal(n, float64(1.23))
+
+	// Integer
+	jv, err = jq.JvFromInterface(456)
+	is.NoErr(err)
+	is.OK(jv)
+	is.Equal(jv.Kind(), jq.JV_KIND_NUMBER)
+	gv = jv.ToGoVal()
+	n2, ok := gv.(int)
+	is.True(ok)
+	is.Equal(n2, 456)
+
+	// String
+	jv, err = jq.JvFromInterface("test")
+	is.NoErr(err)
+	is.OK(jv)
+	is.Equal(jv.Kind(), jq.JV_KIND_STRING)
+	gv = jv.ToGoVal()
+	s, ok := gv.(string)
+	is.True(ok)
+	is.Equal(s, "test")
+
+	jv, err = jq.JvFromInterface([]string{"test", "one", "two"})
+	is.NoErr(err)
+	is.OK(jv)
+	is.Equal(jv.Kind(), jq.JV_KIND_ARRAY)
+	is.Equal(jv.Copy().ArrayLength(), 3)
+	pos2 := jv.Copy().ArrayGet(2)
+	is.OK(pos2)
+	is.Equal(pos2.Kind(), jq.JV_KIND_STRING)
+	gv = pos2.ToGoVal()
+	s, ok = gv.(string)
+	is.True(ok)
+	is.Equal(s, "two")
+
+	jv, err = jq.JvFromInterface(map[string]int{"one": 1, "two": 2})
+	is.NoErr(err)
+	is.OK(jv)
+	is.Equal(jv.Kind(), jq.JV_KIND_OBJECT)
+	t.Log(jv.Copy().Dump(jq.JvPrintPretty | jq.JvPrintColour))
+}
+
 func TestJvDump(t *testing.T) {
 	is := is.New(t)
 

--- a/jq/jv_test.go
+++ b/jq/jv_test.go
@@ -132,20 +132,15 @@ func TestJvFromInterface(t *testing.T) {
 	is.NoErr(err)
 	is.OK(jv)
 	is.Equal(jv.Kind(), jq.JV_KIND_ARRAY)
-	is.Equal(jv.Copy().ArrayLength(), 3)
-	pos2 := jv.Copy().ArrayGet(2)
-	is.OK(pos2)
-	is.Equal(pos2.Kind(), jq.JV_KIND_STRING)
-	gv = pos2.ToGoVal()
-	s, ok = gv.(string)
-	is.True(ok)
-	is.Equal(s, "two")
+	gv = jv.ToGoVal()
+	is.Equal(gv.([]interface{})[2], "two")
 
 	jv, err = jq.JvFromInterface(map[string]int{"one": 1, "two": 2})
 	is.NoErr(err)
 	is.OK(jv)
 	is.Equal(jv.Kind(), jq.JV_KIND_OBJECT)
-	t.Log(jv.Copy().Dump(jq.JvPrintPretty | jq.JvPrintColour))
+	gv = jv.ToGoVal()
+	is.Equal(gv.(map[string]interface{})["two"], 2)
 }
 
 func TestJvDump(t *testing.T) {


### PR DESCRIPTION
* `JvFromFloat`: JV_KIND_NUMBER from Go float64
* `JvFromBool`: JV_KIND_FALSE / JV_KIND_TRUE from Go bool
* `jvFromArray` (private): JV_KIND_ARRAY from reflect.Value representing array or slice
* `jvFromMap` (private): JV_KIND_OBJECT from reflect.Value representing map[string]any
* `JvFromInterface`: Jv from `interface{}` as long as it contains one of:
  * string or []byte (JvFromString)
  * int, [u]int32, [u]int64, float32, or float64 (JvFromFloat)
  * bool (JvFromBool)
  * An array or slice containing any compatible value (jvFromArray)
  * A map from string to any compatible value (jvFromMap)

  JvFromInterface is both the public interface to jvFromArray/jvFromMap, and necessary to their operation.

* `ToGoVal`: now supports JV_KIND_ARRAY (into `[]interface{}`) and JV_KIND_OBJECT (into `map[string]interface{}`) instead of panicking.

Mapping JV_KIND_OBJECT to and from structs is not supported (use `encoding/json` and JvFromJSONBytes / Dump).