### PR TITLE
Add handling for structs in JvFromInterface by marshalling struct to JSON

### DIFF
--- a/jq/jv.go
+++ b/jq/jv.go
@@ -10,6 +10,7 @@ package jq
 */
 import "C"
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -194,6 +195,12 @@ func JvFromInterface(intf interface{}) (*Jv, error) {
 		return jvFromArray(val)
 	case reflect.Map:
 		return jvFromMap(val)
+	case reflect.Struct:
+		marshalled, err := json.Marshal(val)
+		if err != nil {
+			return nil, err
+		}
+		return JvFromJSONString(string(marshalled))
 	default:
 		return nil, errors.New("JvFromInterface can't handle " + val.Kind().String())
 	}

--- a/jq/jv_test.go
+++ b/jq/jv_test.go
@@ -141,6 +141,20 @@ func TestJvFromInterface(t *testing.T) {
 	is.Equal(jv.Kind(), jq.JV_KIND_OBJECT)
 	gv = jv.ToGoVal()
 	is.Equal(gv.(map[string]interface{})["two"], 2)
+
+	aStruct := struct {
+		One int `json:"one"`
+		Two int `json:"two"`
+	}{
+		One: 1,
+		Two: 2,
+	}
+	jv, err = jq.JvFromInterface(aStruct)
+	is.NoErr(err)
+	is.OK(jv)
+	is.Equal(jv.Kind(), jq.JV_KIND_OBJECT)
+	gv = jv.ToGoVal()
+	is.Equal(gv.(map[string]interface{})["two"], 2)
 }
 
 func TestJvDump(t *testing.T) {


### PR DESCRIPTION
# What

- add handling in `JvFromInterface` for creating `Jv`s from `struct`s or entities containing them

# Why

Currently this is possible on the caller side by marshaling the object into a JSON string and calling `JvFromJSONString`. However, I don't see a reason not to implement this directly in the `jq` package.