### PR TITLE
Fix shadowing of jv in generated C for go 1.15

### DIFF
--- a/jq/jq.go
+++ b/jq/jq.go
@@ -116,10 +116,10 @@ var globalErrorChannels = errorLookupState{
 }
 
 //export goLibjqErrorHandler
-func goLibjqErrorHandler(id uint64, jv C.jv) {
+func goLibjqErrorHandler(id uint64, value C.jv) {
 	ch := globalErrorChannels.Get(id)
 
-	err := _ConvertError(jv)
+	err := _ConvertError(value)
 	ch <- err
 }
 


### PR DESCRIPTION
Fixes #13.

cgo 1.15 apparently switched from p0, p1, etc to preserving argument names. This introduced a naming clash for `jv`.

## go 1.14

```c
CGO_NO_SANITIZE_THREAD
void goLibjqErrorHandler(GoUint64 p0, jv p1)
{
	__SIZE_TYPE__ _cgo_ctxt = _cgo_wait_runtime_init_done();
	struct {
		GoUint64 p0;
		jv p1;
	} __attribute__((__packed__, __gcc_struct__)) a;
	a.p0 = p0;
	a.p1 = p1;
	_cgo_tsan_release();
	crosscall2(_cgoexp_3ade700565aa_goLibjqErrorHandler, &a, 24, _cgo_ctxt);
	_cgo_tsan_acquire();
	_cgo_release_context(_cgo_ctxt);
}
```

## go 1.15 (currently)
```c
CGO_NO_SANITIZE_THREAD
void goLibjqErrorHandler(GoUint64 id, jv jv)   // <-- shadowing occurs here
{
	__SIZE_TYPE__ _cgo_ctxt = _cgo_wait_runtime_init_done();
	struct {
		GoUint64 p0;
		jv p1;         // <--  error: unknown type name 'jv'
	} __attribute__((__packed__)) _cgo_a;
	_cgo_a.p0 = id;
	_cgo_a.p1 = jv;
	_cgo_tsan_release();
	crosscall2(_cgoexp_1a11dafe0c9a_goLibjqErrorHandler, &_cgo_a, 24, _cgo_ctxt);
	_cgo_tsan_acquire();
	_cgo_release_context(_cgo_ctxt);
}
```

### Error message
```
$ go get github.com/ashb/jqrepl/jq
go: found github.com/ashb/jqrepl/jq in github.com/ashb/jqrepl v0.1.0
# github.com/ashb/jqrepl/jq
_cgo_export.c:29:3: error: unknown type name 'jv'
```

## go 1.15 patched
```c
CGO_NO_SANITIZE_THREAD
void goLibjqErrorHandler(GoUint64 id, jv value)
{
	__SIZE_TYPE__ _cgo_ctxt = _cgo_wait_runtime_init_done();
	struct {
		GoUint64 p0;
		jv p1;
	} __attribute__((__packed__)) _cgo_a;
	_cgo_a.p0 = id;
	_cgo_a.p1 = value;
	_cgo_tsan_release();
	crosscall2(_cgoexp_1a11dafe0c9a_goLibjqErrorHandler, &_cgo_a, 24, _cgo_ctxt);
	_cgo_tsan_acquire();
	_cgo_release_context(_cgo_ctxt);
}
```