### PR TITLE
Fix mistype in Struct marshalling (from #10)

### DIFF
--- a/jq/jv.go
+++ b/jq/jv.go
@@ -196,7 +196,7 @@ func JvFromInterface(intf interface{}) (*Jv, error) {
 	case reflect.Map:
 		return jvFromMap(val)
 	case reflect.Struct:
-		marshalled, err := json.Marshal(val)
+		marshalled, err := json.Marshal(intf)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The original PR was marshalling the `reflect.Value` interface instead of the actual given value, so it seems to always yield `{}`. This fixes the test suite for me (on go 1.15)